### PR TITLE
fixes column names so that migrations will run

### DIFF
--- a/server/database/migrations/1637028716848-AddUser.ts
+++ b/server/database/migrations/1637028716848-AddUser.ts
@@ -7,7 +7,7 @@ export class AddUser1637028716848 implements MigrationInterface {
         name: 'user',
         columns: [
           {
-            name: 'userId',
+            name: 'id',
             type: 'int',
             isPrimary: true,
             isGenerated: true,

--- a/server/database/migrations/1643904163026-Project.ts
+++ b/server/database/migrations/1643904163026-Project.ts
@@ -7,7 +7,7 @@ export default class Project1643904163026 implements MigrationInterface {
         name: 'project',
         columns: [
           {
-            name: 'projectId',
+            name: 'id',
             type: 'int',
             isPrimary: true,
             isGenerated: true,

--- a/server/database/migrations/1643940358630-Task.ts
+++ b/server/database/migrations/1643940358630-Task.ts
@@ -7,7 +7,7 @@ export class Task1643940358630 implements MigrationInterface {
         name: 'task',
         columns: [
           {
-            name: 'taskId',
+            name: 'id',
             type: 'int',
             isPrimary: true,
             isGenerated: true,

--- a/server/database/migrations/1643940387616-userProjects.ts
+++ b/server/database/migrations/1643940387616-userProjects.ts
@@ -7,9 +7,14 @@ export class userProjects1643940387616 implements MigrationInterface {
         name: 'userProjects',
         columns: [
           {
-            name: 'userId',
+            name: 'id',
             type: 'int',
             isPrimary: true,
+            isNullable: false,
+          },
+          {
+            name: 'userId',
+            type: 'int',
             isNullable: false,
           },
           {


### PR DESCRIPTION
Hi Jacob and Team!

Sorry it took me so long. I looked at your project and a couple of notes, this PR fixes the first issue, I will let you guys handle the rest!

1. The primary key column for each table should just build called `id` instead of `projectId`, `taskId` ect... This was the cause of your issue because typeORM assumes the name of the primary key is `id` for each table, and renaming the id column in the user migration broke later migrations. This PR fixes those issues. I did NOT update the entities, so make sure you update your entity files also!
2. You project should have a "name" column.
3. You need to add foreign key constraints to your projects and to your tasks. Look at the AddRoles migration for an example of how to do this.
4. Entities look good!
